### PR TITLE
Disable button when spinner is active

### DIFF
--- a/src/module/component/spinner-button.component.html
+++ b/src/module/component/spinner-button.component.html
@@ -7,7 +7,7 @@
   [class.mat-stroked-button]="options.stroked"
   [class.mat-flat-button]="options.flat"
   [class.mat-fab]="options.fab"
-  [disabled]="options.disabled">
+  [disabled]="options.active || options.disabled">
 
   <span
     class="button-text"


### PR DESCRIPTION
#In order to make the spinner button behave the same as the progress button when they are clicked I've added the options.active check to the [disabled] property.  I pulled it down locally and made the change and tested in the demo app successfully. #31 