### PR TITLE
feat(lib): add [active] and [disabled] inputs

### DIFF
--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -58,6 +58,12 @@
 					<div style="padding: 30px;">
 						<p><strong>[options]</strong></p>
 						<pre><code [highlight]="strokedOpts" language="['typescript']"></code></pre>
+						<p><strong>[active]</strong></p>
+						<p>The active option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the active state in the component.</p>
+						<pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
+						<p><strong>[disabled]</strong></p>
+						<p>The disabled option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the disabled state in the component.</p>
+						<pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
 					</div>
 				</mat-tab>
 			</mat-tab-group>
@@ -95,6 +101,12 @@
 					<div style="padding: 30px;">
 						<p><strong>[options]</strong></p>
 						<pre><code [highlight]="raisedOpts" language="['typescript']"></code></pre>
+						<p><strong>[active]</strong></p>
+						<p>The active option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the active state in the component.</p>
+						<pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
+						<p><strong>[disabled]</strong></p>
+						<p>The disabled option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the disabled state in the component.</p>
+						<pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
 					</div>
 				</mat-tab>
 			</mat-tab-group>

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -66,7 +66,8 @@ export class HomeComponent implements OnInit {
     disabled: boolean,
     customClass: 'some-class',
     mode: string`;
-
+  activeCode = `   [active]="active$ | async"`;
+  disabledCode = `   [disabled]="disabled$ | async"`;
   raisedCode = `  import { Component } from '@angular/core';
   import { MatProgressButtonOptions } from 'mat-progress-buttons';
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mat-progress-buttons",
   "description": "Material Design Progress Buttons",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "homepage": "https://github.com/michaeldoye/mat-progress-buttons",
   "author": {
     "name": "Michael Doye",

--- a/src/module/component/bar-button/bar-button.component.ts
+++ b/src/module/component/bar-button/bar-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, HostListener } from '@angular/core';
+import { Component, Input, Output, EventEmitter, HostListener, OnChanges, SimpleChanges } from '@angular/core';
 import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
 
 @Component({
@@ -7,13 +7,24 @@ import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
   templateUrl: './bar-button.component.html',
   styleUrls: ['./bar-button.component.scss']
 })
-export class MatBarButtonComponent {
+export class MatBarButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
+  @Input() active: boolean;
+  @Input() disabled: boolean;
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent) {
     if (!this.options.disabled && !this.options.active) {
       this.btnClick.emit(event);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.active) {
+      this.options.active = changes.active.currentValue;
+    }
+    if (changes.disabled) {
+      this.options.disabled = changes.disabled.currentValue;
     }
   }
 }

--- a/src/module/component/spinner-button/spinner-button.component.ts
+++ b/src/module/component/spinner-button/spinner-button.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, HostListener, EventEmitter } from '@angular/core';
+import { Component, Input, Output, HostListener, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
 import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
 
 @Component({
@@ -7,13 +7,25 @@ import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
   templateUrl: './spinner-button.component.html',
   styleUrls: ['./spinner-button.component.scss']
 })
-export class MatSpinnerButtonComponent {
+export class MatSpinnerButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
+  @Input() active: boolean;
+  @Input() disabled: boolean;
+
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent) {
     if (!this.options.disabled && !this.options.active) {
       this.btnClick.emit(event);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes.active) {
+      this.options.active = changes.active.currentValue;
+    }
+    if (changes.disabled) {
+      this.options.disabled = changes.disabled.currentValue;
     }
   }
 }


### PR DESCRIPTION
This feature request PR adds two new Inputs to the buttons component to be able to manipulate the "active" and "disabled" state directly to be able to use template observables.

The following scenario describes the use case:

Using a component together with ngrx/store and the facade pattern I'm trying to keep the component as clean as possible. 

By injecting the facade into the component and making it publicly available 

```
  constructor(public f: BundlesFacade) { }
```

I can access all the relevant members of the facade
```
export class BundlesFacade {
  loaded$           = this.store.pipe(select(bundlesQuery.getLoaded));
  loading$          = this.store.pipe(select(bundlesQuery.getLoading));
  list$                 = this.store.pipe(select(bundlesQuery.getAllBundles));
}
```
directly in the angular template
```
<mat-spinner-button (btnClick)="onSubmit()" [options]="btnOpts" [active]="f.loading$ | async">
</mat-spinner-button>
```

Without the "active" Input one needs to make subscribe to the "loading$" in the component and manipulate the "options" and also unsubscribe. 

The proposed changes lead to cleaner components using them with ngrx/store states.