### PR TITLE
feat(lib): add global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ To set up fontawesome to work with `mat-icon` you can see instructions [here](ht
 
 Use the `icon` property on the `options` object
 
+**Note**: Bar Button does not support the `fab` style, currently.
+
+
 ```
   btnOpts: MatProgressButtonOptions = {
     active: false,
@@ -195,13 +198,47 @@ export class SomeComponent {
 
   // Click handler
   btnClick(): void {
-    this.btnOpts.active = true;
+    this.btnOpts = { ...this.btnOpts, active: true };
     setTimeout(() => {
-      this.btnOpts.active = false;
+      this.btnOpts = { ...this.btnOpts, active: false };
     }, 3350);
   }
 };
 ```
+
+### Global Options
+
+Optionally pass default `MatProgressButtonOptions` in `forRoot` in side your app.modlue.ts for each button as an array. 
+
+```typescript
+const button1: MatProgressButtonOptions = {
+  id: 'button1', // Id should match the [buttonId] input
+  ...
+};
+
+const button2: MatProgressButtonOptions = {
+  id: 'button2', // Id should match the [buttonId] input
+  ...
+};
+
+@NgModule({
+  imports: [
+    MatProgressButtonsModule.forRoot([button1, button2]),
+  ],
+  declarations: [HomeComponent],
+})
+```
+
+#### NB: add the id above should match the id provided in the `[buttonId]` input.
+
+```html
+<mat-bar-button
+  (btnClick)="someFunc3()"
+  [buttonId]="'button1'"
+  [options]="barButtonOptions"
+></mat-bar-button>
+```
+`[options]` on the component will override Global Options provided in `forRoot`
 
 ### Overriding default CSS
 
@@ -211,22 +248,21 @@ Example:
 
 CSS:
 
-```
-.class_name {
-    background-color: red; // etc.
+```css
+.class-name {
+    background-color: red;
 }
 ```
 
 TS:
 
-```
+```typescript
 @Component({
   ...,
-  encapsulation : ViewEncapsulation.None // Here
+  encapsulation: ViewEncapsulation.None
 })
+class MyComponent {}
 ```
-
-**Note**: Bar Button does not suppor the `fab` style, currently. Hope to have something like [this](https://codepen.io/DevVersion/pen/vGebGB) soon.
 
 <a name="run-demo-app-locally"/>
 
@@ -278,9 +314,9 @@ $ ng serve --open
 1. clone this [repo](https://github.com/michaeldoye/mat-progress-buttons.git)
 2. Install the dependencies by running `npm i`
 3. build the library `ng buld`
-3. test the library `ng test`
-4. Link the library `npm link ./dist/mat-progress-buttons`
- 5. Navigate to the demo app's directory:
+4. test the library `ng test`
+5. Link the library `npm link ./dist/mat-progress-buttons`
+6. Navigate to the demo app's directory:
   - `cd demo`
   - `npm i`
   - `npm start`

--- a/README.md
+++ b/README.md
@@ -235,10 +235,10 @@ const button2: MatProgressButtonOptions = {
 <mat-bar-button
   (btnClick)="someFunc3()"
   [buttonId]="'button1'"
-  [options]="barButtonOptions"
+  [active]="buttonState"
 ></mat-bar-button>
 ```
-`[options]` on the component will override Global Options provided in `forRoot`
+`[options]` will override Global Options provided in `forRoot`
 
 ### Overriding default CSS
 

--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -105,6 +105,16 @@
               unsubscribe to the disabled state in the component.
             </p>
             <pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
+            <p><strong>Global Options</strong></p>
+            <p>
+              Optionally pass default `MatProgressButtonOptions` in `forRoot` in side
+              your app.modlue.ts for each button as an array.
+            </p>
+            <pre><code [highlight]="globalOpts" language="['typescript']"></code></pre>
+            <pre><code [highlight]="globalOptsHtml" language="['html']"></code></pre>
+            <p>
+              [options] will override Global Options provided in `forRoot`
+            </p>
           </div>
         </mat-tab>
       </mat-tab-group>
@@ -134,7 +144,8 @@
             <mat-bar-button
               (btnClick)="someFunc3()"
               [buttonId]="'button1'"
-              [options]="barButtonOptions"
+              [active]="barButtonOptionsActiveState"
+              [disabled]="false"
             ></mat-bar-button>
             <mat-bar-button
               (btnClick)="someFunc4()"
@@ -177,6 +188,16 @@
               unsubscribe to the disabled state in the component.
             </p>
             <pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
+            <p><strong>Global Options</strong></p>
+            <p>
+              Optionally pass default `MatProgressButtonOptions` in `forRoot` in side
+              your app.modlue.ts for each button as an array.
+            </p>
+            <pre><code [highlight]="globalOpts" language="['typescript']"></code></pre>
+            <pre><code [highlight]="globalOptsHtml" language="['html']"></code></pre>
+            <p>
+              [options] will override Global Options provided in `forRoot`
+            </p>
           </div>
         </mat-tab>
       </mat-tab-group>

--- a/demo/src/app/home/home.component.html
+++ b/demo/src/app/home/home.component.html
@@ -1,116 +1,185 @@
 <div class="jumbotron jumbotron-fluid">
-	<div class="container">
-		<div class="row">
-			<div class="col-sm-4 d-flex justify-content-center justify-content-md-end">
-				<img src="assets/logo.svg" alt="mat-progress-buttons logo" class="logo">
-			</div>
-			<div class="col-sm-8 text-center text-md-left">
-				<h1>Mat Progress Buttons</h1>
-				<p>Angular Material Design Buttons With Progress indicators</p>
-				<p>Scroll down to see it in action!</p>
-				<p class="buttons">
-					<a mat-stroked-button color="primary" href="https://github.com/michaeldoye/mat-progress-buttons" target="_blank"><i class="fa fa-github fa-lg"></i>  Code on Github</a>
-					<a mat-stroked-button color="primary" href="https://github.com/michaeldoye/mat-progress-buttons#installation" target="_blank"><i class="fa fa-book fa-lg"></i>  Documentation</a>
-					<a mat-stroked-button color="primary" href="#" (click)="editOnStackBlitz()"><i class="fa fa-bolt fa-lg"></i>  Edit on StackBlitz</a>
-        		</p>
-			</div>
-		</div>
-	</div>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-4 d-flex justify-content-center justify-content-md-end">
+        <img src="assets/logo.svg" alt="mat-progress-buttons logo" class="logo" />
+      </div>
+      <div class="col-sm-8 text-center text-md-left">
+        <h1>Mat Progress Buttons</h1>
+        <p>Angular Material Design Buttons With Progress indicators</p>
+        <p>Scroll down to see it in action!</p>
+        <p class="buttons">
+          <a
+            mat-stroked-button
+            color="primary"
+            href="https://github.com/michaeldoye/mat-progress-buttons"
+            target="_blank"
+            ><i class="fa fa-github fa-lg"></i> Code on Github</a
+          >
+          <a
+            mat-stroked-button
+            color="primary"
+            href="https://github.com/michaeldoye/mat-progress-buttons#installation"
+            target="_blank"
+            ><i class="fa fa-book fa-lg"></i> Documentation</a
+          >
+          <a mat-stroked-button color="primary" href="#" (click)="editOnStackBlitz()"
+            ><i class="fa fa-bolt fa-lg"></i> Edit on StackBlitz</a
+          >
+        </p>
+      </div>
+    </div>
+  </div>
 </div>
-
-
-
 
 <section class="home">
   <div class="container">
-		<!-- put your content here-->
-		<h2>Progress Spinner Button</h2>
-		<hr />
+    <!-- put your content here-->
+    <h2>Progress Spinner Button</h2>
+    <hr />
 
-		<div class="example-container">
-			<mat-toolbar>
-				<p class="example-header">
-					<span>Demo</span>
-					<span class="pull-right">
-						<a href="https://stackblitz.com/edit/mat-progress-buttons-demo" target="_blank" mat-icon-button matTooltip="Open in StackBlitz">
-							<i class="fa fa-bolt fa-lg"></i>
-						</a>
-					</span>
-				</p>
-			</mat-toolbar>
-			<mat-tab-group mat-stretch-tabs>
-				<mat-tab label="Preview">
-					<div style="padding: 30px;">
-						<mat-spinner-button (btnClick)="someFunc()" [options]="spinnerButtonOptions"></mat-spinner-button>
-						<mat-spinner-button (btnClick)="someFunc1()" [options]="spinnerButtonOptions1"></mat-spinner-button>
-						<mat-spinner-button (btnClick)="someFunc2()" [options]="spinnerButtonOptions2"></mat-spinner-button>
-						<mat-spinner-button (btnClick)="someFunc6()" [options]="spinnerButtonOptions3"></mat-spinner-button>
-						<mat-spinner-button (btnClick)="someFunc8()" [options]="spinnerButtonOptions4"></mat-spinner-button>
-					</div>
-				</mat-tab>
-				<mat-tab label="Usage">
-					<div style="padding: 30px;">
-						<p><strong>Component</strong></p>
-						<pre><code [highlight]="strokedCode" language="['typescript']"></code></pre>
-					</div>
-				</mat-tab>
-				<mat-tab label="Options">
-					<div style="padding: 30px;">
-						<p><strong>[options]</strong></p>
-						<pre><code [highlight]="strokedOpts" language="['typescript']"></code></pre>
-						<p><strong>[active]</strong></p>
-						<p>The active option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the active state in the component.</p>
-						<pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
-						<p><strong>[disabled]</strong></p>
-						<p>The disabled option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the disabled state in the component.</p>
-						<pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
-					</div>
-				</mat-tab>
-			</mat-tab-group>
-		</div>
+    <div class="example-container">
+      <mat-toolbar>
+        <p class="example-header">
+          <span>Demo</span>
+          <span class="pull-right">
+            <a
+              href="https://stackblitz.com/edit/mat-progress-buttons-demo"
+              target="_blank"
+              mat-icon-button
+              matTooltip="Open in StackBlitz"
+            >
+              <i class="fa fa-bolt fa-lg"></i>
+            </a>
+          </span>
+        </p>
+      </mat-toolbar>
+      <mat-tab-group mat-stretch-tabs>
+        <mat-tab label="Preview">
+          <div style="padding: 30px">
+            <mat-spinner-button
+              (btnClick)="someFunc()"
+              [options]="spinnerButtonOptions"
+            ></mat-spinner-button>
+            <mat-spinner-button
+              (btnClick)="someFunc1()"
+              [options]="spinnerButtonOptions1"
+            ></mat-spinner-button>
+            <mat-spinner-button
+              (btnClick)="someFunc2()"
+              [options]="spinnerButtonOptions2"
+            ></mat-spinner-button>
+            <mat-spinner-button
+              (btnClick)="someFunc6()"
+              [options]="spinnerButtonOptions3"
+            ></mat-spinner-button>
+            <mat-spinner-button
+              (btnClick)="someFunc8()"
+              [options]="spinnerButtonOptions4"
+            ></mat-spinner-button>
+          </div>
+        </mat-tab>
+        <mat-tab label="Usage">
+          <div style="padding: 30px">
+            <p><strong>Component</strong></p>
+            <pre><code [highlight]="strokedCode" language="['typescript']"></code></pre>
+          </div>
+        </mat-tab>
+        <mat-tab label="Options">
+          <div style="padding: 30px">
+            <p><strong>[options]</strong></p>
+            <pre><code [highlight]="strokedOpts" language="['typescript']"></code></pre>
+            <p><strong>[active]</strong></p>
+            <p>
+              The active option can be manipulated separately to be able to use
+              observables variables inside of the angular template syntax (e.g. in
+              usage with ngrx/store selectors) instead of having to subscribe and
+              unsubscribe to the active state in the component.
+            </p>
+            <pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
+            <p><strong>[disabled]</strong></p>
+            <p>
+              The disabled option can be manipulated separately to be able to use
+              observables variables inside of the angular template syntax (e.g. in
+              usage with ngrx/store selectors) instead of having to subscribe and
+              unsubscribe to the disabled state in the component.
+            </p>
+            <pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
 
-		<h2>Progress Bar Button</h2>
-		<hr />
-		<div class="example-container">
-			<mat-toolbar>
-				<p class="example-header">
-					<span>Demo</span>
-					<span class="pull-right">
-						<a href="https://stackblitz.com/edit/mat-progress-buttons-demo" target="_blank" mat-icon-button matTooltip="Open in StackBlitz">
-							<i class="fa fa-bolt fa-lg"></i>
-						</a>
-					</span>
-				</p>
-			</mat-toolbar>
-			<mat-tab-group mat-stretch-tabs>
-				<mat-tab label="Preview">
-					<div style="padding: 30px;">
-						<mat-bar-button (btnClick)="someFunc3()" [options]="barButtonOptions"></mat-bar-button>
-						<mat-bar-button (btnClick)="someFunc4()" [options]="barButtonOptions1"></mat-bar-button>
-						<mat-bar-button (btnClick)="someFunc5()" [options]="barButtonOptions2"></mat-bar-button>
-						<mat-bar-button (btnClick)="someFunc7()" [options]="barButtonOptions3"></mat-bar-button>
-					</div>
-				</mat-tab>
-				<mat-tab label="Usage">
-					<div style="padding: 30px;">
-						<p><strong>Component</strong></p>
-						<pre><code [highlight]="raisedCode" language="['typescript']"></code></pre>
-					</div>
-				</mat-tab>
-				<mat-tab label="Options">
-					<div style="padding: 30px;">
-						<p><strong>[options]</strong></p>
-						<pre><code [highlight]="raisedOpts" language="['typescript']"></code></pre>
-						<p><strong>[active]</strong></p>
-						<p>The active option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the active state in the component.</p>
-						<pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
-						<p><strong>[disabled]</strong></p>
-						<p>The disabled option can be manipulated separately to be able to use observables variables inside of the angular template syntax (e.g. in usage with ngrx/store selectors) instead of having to subscribe and unsubscribe to the disabled state in the component.</p>
-						<pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
-					</div>
-				</mat-tab>
-			</mat-tab-group>
-		</div>
-
+    <h2>Progress Bar Button</h2>
+    <hr />
+    <div class="example-container">
+      <mat-toolbar>
+        <p class="example-header">
+          <span>Demo</span>
+          <span class="pull-right">
+            <a
+              href="https://stackblitz.com/edit/mat-progress-buttons-demo"
+              target="_blank"
+              mat-icon-button
+              matTooltip="Open in StackBlitz"
+            >
+              <i class="fa fa-bolt fa-lg"></i>
+            </a>
+          </span>
+        </p>
+      </mat-toolbar>
+      <mat-tab-group mat-stretch-tabs>
+        <mat-tab label="Preview">
+          <div style="padding: 30px">
+            <mat-bar-button
+              (btnClick)="someFunc3()"
+              [buttonId]="'button1'"
+              [options]="barButtonOptions"
+            ></mat-bar-button>
+            <mat-bar-button
+              (btnClick)="someFunc4()"
+              [buttonId]="'button2'"
+              [options]="barButtonOptions1"
+            ></mat-bar-button>
+            <mat-bar-button
+              (btnClick)="someFunc5()"
+              [options]="barButtonOptions2"
+            ></mat-bar-button>
+            <mat-bar-button
+              (btnClick)="someFunc7()"
+              [options]="barButtonOptions3"
+            ></mat-bar-button>
+          </div>
+        </mat-tab>
+        <mat-tab label="Usage">
+          <div style="padding: 30px">
+            <p><strong>Component</strong></p>
+            <pre><code [highlight]="raisedCode" language="['typescript']"></code></pre>
+          </div>
+        </mat-tab>
+        <mat-tab label="Options">
+          <div style="padding: 30px">
+            <p><strong>[options]</strong></p>
+            <pre><code [highlight]="raisedOpts" language="['typescript']"></code></pre>
+            <p><strong>[active]</strong></p>
+            <p>
+              The active option can be manipulated separately to be able to use
+              observables variables inside of the angular template syntax (e.g. in
+              usage with ngrx/store selectors) instead of having to subscribe and
+              unsubscribe to the active state in the component.
+            </p>
+            <pre><code [highlight]="activeCode" language="['typescript']"></code></pre>
+            <p><strong>[disabled]</strong></p>
+            <p>
+              The disabled option can be manipulated separately to be able to use
+              observables variables inside of the angular template syntax (e.g. in
+              usage with ngrx/store selectors) instead of having to subscribe and
+              unsubscribe to the disabled state in the component.
+            </p>
+            <pre><code [highlight]="disabledCode" language="['typescript']"></code></pre>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
   </div>
 </section>

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -7,7 +7,7 @@ import { MatProgressButtonOptions } from 'mat-progress-buttons';
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
   strokedCode = `  import { Component } from '@angular/core';
@@ -48,9 +48,9 @@ export class HomeComponent implements OnInit {
 
     // Click handler
     btnClick(): void {
-      this.btnOpts.active = true;
+      this.btnOpts = { ...this.btnOpts, active: true };
       setTimeout(() => {
-        this.btnOpts.active = false;
+        this.btnOpts = { ...this.btnOpts, active: false };
       }, 3350);
     }
   }`;
@@ -99,9 +99,9 @@ export class HomeComponent implements OnInit {
 
     // Click handler
     btnClick(): void {
-      this.btnOpts.active = true;
+      this.btnOpts = { ...this.btnOpts, active: true };
       setTimeout(() => {
-        this.btnOpts.active = false;
+        this.btnOpts = { ...this.btnOpts, active: false };
       }, 3350);
     }
   }`;
@@ -157,7 +157,7 @@ export class HomeComponent implements OnInit {
     spinnerColor: 'primary',
     fullWidth: false,
     disabled: false,
-    mode: 'indeterminate'
+    mode: 'indeterminate',
   };
 
   spinnerButtonOptions3: MatProgressButtonOptions = {
@@ -190,36 +190,16 @@ export class HomeComponent implements OnInit {
     icon: {
       fontSet: 'fa',
       fontIcon: 'fa-heart',
-      inline: true
+      inline: true,
     },
   };
 
   barButtonOptions: MatProgressButtonOptions = {
-    active: false,
     text: 'Stroked Button',
-    buttonColor: 'accent',
-    barColor: 'accent',
-    raised: false,
-    stroked: true,
-    mode: 'indeterminate',
-    value: 0,
-    disabled: false,
-    customClass: 'some-other-class',
-    buttonIcon: {
-      fontIcon: 'favorite',
-    },
   };
 
   barButtonOptions1: MatProgressButtonOptions = {
-    active: false,
     text: 'Raised Button',
-    buttonColor: 'primary',
-    barColor: 'primary',
-    raised: true,
-    stroked: false,
-    mode: 'indeterminate',
-    value: 0,
-    disabled: false
   };
 
   barButtonOptions2: MatProgressButtonOptions = {
@@ -231,7 +211,7 @@ export class HomeComponent implements OnInit {
     stroked: false,
     mode: 'indeterminate',
     value: 0,
-    disabled: false
+    disabled: false,
   };
 
   barButtonOptions3: MatProgressButtonOptions = {
@@ -244,7 +224,7 @@ export class HomeComponent implements OnInit {
     flat: true,
     mode: 'indeterminate',
     value: 0,
-    disabled: false
+    disabled: false,
   };
 
   constructor(private titleService: Title) {}
@@ -258,65 +238,65 @@ export class HomeComponent implements OnInit {
   }
 
   someFunc(): void {
-    this.spinnerButtonOptions.active = true;
+    this.spinnerButtonOptions = { ...this.spinnerButtonOptions, active: true };
     setTimeout(() => {
-      this.spinnerButtonOptions.active = false;
+      this.spinnerButtonOptions = { ...this.spinnerButtonOptions, active: false };
     }, 3350);
   }
 
   someFunc1(): void {
-    this.spinnerButtonOptions1.active = true;
+    this.spinnerButtonOptions1 = { ...this.spinnerButtonOptions1, active: true };
     setTimeout(() => {
-      this.spinnerButtonOptions1.active = false;
+      this.spinnerButtonOptions1 = { ...this.spinnerButtonOptions1, active: false };
     }, 3350);
   }
 
   someFunc2(): void {
-    this.spinnerButtonOptions2.active = true;
+    this.spinnerButtonOptions2 = { ...this.spinnerButtonOptions2, active: true };
     setTimeout(() => {
-      this.spinnerButtonOptions2.active = false;
+      this.spinnerButtonOptions2 = { ...this.spinnerButtonOptions2, active: false };
     }, 3350);
   }
 
   someFunc3(): void {
-    this.barButtonOptions.active = true;
+    this.barButtonOptions = { ...this.barButtonOptions, active: true };
     setTimeout(() => {
-      this.barButtonOptions.active = false;
+      this.barButtonOptions = { ...this.barButtonOptions, active: false };
     }, 3350);
   }
 
   someFunc4(): void {
-    this.barButtonOptions1.active = true;
+    this.barButtonOptions1 = { ...this.barButtonOptions1, active: true };
     setTimeout(() => {
-      this.barButtonOptions1.active = false;
+      this.barButtonOptions1 = { ...this.barButtonOptions1, active: false };
     }, 3350);
   }
 
   someFunc5(): void {
-    this.barButtonOptions2.active = true;
+    this.barButtonOptions2 = { ...this.barButtonOptions2, active: true };
     setTimeout(() => {
-      this.barButtonOptions2.active = false;
+      this.barButtonOptions2 = { ...this.barButtonOptions2, active: false };
     }, 3350);
   }
 
   someFunc6(): void {
-    this.spinnerButtonOptions3.active = true;
+    this.spinnerButtonOptions3 = { ...this.spinnerButtonOptions3, active: true };
     setTimeout(() => {
-      this.spinnerButtonOptions3.active = false;
+      this.spinnerButtonOptions3 = { ...this.spinnerButtonOptions3, active: false };
     }, 3350);
   }
 
   someFunc7(): void {
-    this.barButtonOptions3.active = true;
+    this.barButtonOptions3 = { ...this.barButtonOptions3, active: true };
     setTimeout(() => {
-      this.barButtonOptions3.active = false;
+      this.barButtonOptions3 = { ...this.barButtonOptions3, active: false };
     }, 3350);
   }
 
   someFunc8(): void {
-    this.spinnerButtonOptions4.active = true;
+    this.spinnerButtonOptions4 = { ...this.spinnerButtonOptions4, active: true };
     setTimeout(() => {
-      this.spinnerButtonOptions4.active = false;
+      this.spinnerButtonOptions4 = { ...this.spinnerButtonOptions4, active: false };
     }, 3350);
   }
 }

--- a/demo/src/app/home/home.component.ts
+++ b/demo/src/app/home/home.component.ts
@@ -15,13 +15,12 @@ export class HomeComponent implements OnInit {
 
   @Component({
     selector: 'app-home',
-    template: '<mat-spinner-button (btnClick)="btnClick()" [options]="btnOpts"></mat-spinner-button>'
+    template: '<mat-spinner-button (btnClick)="btnClick()" [options]="btnOpts" [active]="btnState"></mat-spinner-button>'
   })
   export class SomeComponent {
 
     // Button Options
     btnOpts: MatProgressButtonOptions = {
-      active: false,
       text: 'Stroked Button',
       spinnerSize: 19,
       raised: false,
@@ -46,11 +45,13 @@ export class HomeComponent implements OnInit {
       }
     };
 
+    btnState: boolean = false;
+
     // Click handler
     btnClick(): void {
-      this.btnOpts = { ...this.btnOpts, active: true };
+      this.btnState = true;
       setTimeout(() => {
-        this.btnOpts = { ...this.btnOpts, active: false };
+        this.btnState = false;
       }, 3350);
     }
   }`;
@@ -66,8 +67,30 @@ export class HomeComponent implements OnInit {
     disabled: boolean,
     customClass: 'some-class',
     mode: string`;
-  activeCode = `   [active]="active$ | async"`;
-  disabledCode = `   [disabled]="disabled$ | async"`;
+  activeCode = `[active]="active$ | async"`;
+  disabledCode = `[disabled]="disabled$ | async"`;
+  globalOpts = `
+   const button1: MatProgressButtonOptions = {
+    id: 'button1', // Id should match the [buttonId] input
+    ...
+  };
+
+  const button2: MatProgressButtonOptions = {
+    id: 'button2', // Id should match the [buttonId] input
+    ...
+  };
+
+  @NgModule({
+    imports: [
+      MatProgressButtonsModule.forRoot([button1, button2]),
+    ],
+    declarations: [HomeComponent],
+  })`;
+  globalOptsHtml = `<mat-bar-button
+    (btnClick)="someFunc3()"
+    [buttonId]="'button1'"
+    [active]="buttonState">
+  </mat-bar-button>`;
   raisedCode = `  import { Component } from '@angular/core';
   import { MatProgressButtonOptions } from 'mat-progress-buttons';
 
@@ -79,7 +102,6 @@ export class HomeComponent implements OnInit {
 
     // Button Options
     btnOpts: MatProgressButtonOptions = {
-      active: false,
       text: 'Stroked Button',
       buttonColor: 'accent',
       barColor: 'accent',
@@ -198,6 +220,8 @@ export class HomeComponent implements OnInit {
     text: 'Stroked Button',
   };
 
+  barButtonOptionsActiveState = false;
+
   barButtonOptions1: MatProgressButtonOptions = {
     text: 'Raised Button',
   };
@@ -259,9 +283,9 @@ export class HomeComponent implements OnInit {
   }
 
   someFunc3(): void {
-    this.barButtonOptions = { ...this.barButtonOptions, active: true };
+    this.barButtonOptionsActiveState = true;
     setTimeout(() => {
-      this.barButtonOptions = { ...this.barButtonOptions, active: false };
+      this.barButtonOptionsActiveState = false;
     }, 3350);
   }
 

--- a/demo/src/app/home/home.module.ts
+++ b/demo/src/app/home/home.module.ts
@@ -1,7 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MatProgressButtonsModule } from 'mat-progress-buttons';
+import {
+  MatProgressButtonOptions,
+  MatProgressButtonsModule,
+} from 'mat-progress-buttons';
 import { HighlightModule } from 'ngx-highlightjs';
 import typescript from 'highlight.js/lib/languages/typescript';
 
@@ -13,22 +16,50 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 
 export function hljsLanguages() {
-    return [
-      {name: 'typescript', func: typescript},
-    ];
-  }
+  return [{ name: 'typescript', func: typescript }];
+}
+
+const button1: MatProgressButtonOptions = {
+  id: 'button1',
+  text: 'Stroked Button',
+  buttonColor: 'accent',
+  barColor: 'accent',
+  raised: false,
+  stroked: true,
+  mode: 'indeterminate',
+  value: 0,
+  disabled: false,
+  customClass: 'some-other-class',
+  buttonIcon: {
+    fontIcon: 'favorite',
+  },
+};
+
+const button2: MatProgressButtonOptions = {
+  id: 'button2',
+  text: 'Raised Button',
+  buttonColor: 'primary',
+  barColor: 'primary',
+  raised: true,
+  stroked: false,
+  mode: 'indeterminate',
+  value: 0,
+  disabled: false,
+};
+
 @NgModule({
   imports: [
     CommonModule,
     BrowserAnimationsModule,
-    MatProgressButtonsModule.forRoot(),
+    MatProgressButtonsModule.forRoot([button1, button2]),
     HighlightModule.forRoot({languages: hljsLanguages}),
     HomeRoutingModule,
     MatButtonModule,
     MatTabsModule,
     MatToolbarModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatProgressButtonsModule,
   ],
-    declarations: [HomeComponent],
+  declarations: [HomeComponent],
 })
-export class HomeModule { }
+export class HomeModule {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12062,6 +12062,12 @@
         "uniq": "^1.0.1"
       }
     },
+    "prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.5.0",
     "ng-packagr": "^12.1.2",
+    "prettier": "^2.3.2",
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  printWidth: 200,
+  printWidth: 85,
   singleQuote: true,
 };

--- a/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.html
+++ b/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.html
@@ -1,4 +1,5 @@
-<button mat-button
+<button
+  mat-button
   [type]="options.type"
   [color]="options.buttonColor"
   [class.active]="options.active"
@@ -7,10 +8,9 @@
   [class.mat-flat-button]="options.flat"
   [class.fullWidth]="options.fullWidth"
   [ngClass]="options.customClass"
-  [disabled]="options.active || options.disabled">
-
-  <ng-container
-    *ngIf="options.buttonIcon">
+  [disabled]="options.active || options.disabled"
+>
+  <ng-container *ngIf="options.buttonIcon">
     <mat-icon
       [class.is-mat-icon]="!options.buttonIcon.fontSet"
       [ngClass]="options.buttonIcon.customClass"
@@ -18,7 +18,8 @@
       [fontIcon]="options.buttonIcon.fontIcon"
       [color]="options.buttonIcon.color"
       [svgIcon]="options.buttonIcon.svgIcon"
-      [inline]="options.buttonIcon.inline">
+      [inline]="options.buttonIcon.inline"
+    >
       {{ options.buttonIcon.fontSet ? '' : options.buttonIcon.fontIcon }}
     </mat-icon>
   </ng-container>
@@ -30,6 +31,7 @@
     *ngIf="options.active && !options.disabled"
     [color]="options.barColor"
     [mode]="options.mode"
-    [value]="options.value">
+    [value]="options.value"
+  >
   </mat-progress-bar>
 </button>

--- a/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.spec.ts
+++ b/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.spec.ts
@@ -6,11 +6,18 @@ describe('MatBarButtonComponent', () => {
   let component: MatBarButtonComponent;
   let fixture: ComponentFixture<MatBarButtonComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatProgressButtonsModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          MatProgressButtonsModule.forRoot([{ active: true, text: 'test' }]),
+        ],
+        providers: [
+          { provide: 'Global Config', useValue: { active: true, text: 'test' } },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MatBarButtonComponent);
@@ -20,7 +27,7 @@ describe('MatBarButtonComponent', () => {
       active: false,
       buttonColor: 'primary',
       text: 'test button',
-      disabled: false
+      disabled: false,
     };
     fixture.detectChanges();
   });
@@ -34,7 +41,7 @@ describe('MatBarButtonComponent', () => {
     component.btnClick.subscribe(spy);
 
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith(event);
@@ -46,7 +53,7 @@ describe('MatBarButtonComponent', () => {
 
     component.options = { active: true, text: 'test button' };
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -57,7 +64,7 @@ describe('MatBarButtonComponent', () => {
 
     component.options = { active: false, disabled: true, text: 'test button' };
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).not.toHaveBeenCalled();
   });

--- a/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.ts
+++ b/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.ts
@@ -1,30 +1,48 @@
-import { Component, Input, Output, EventEmitter, HostListener, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  HostListener,
+  OnChanges,
+  SimpleChanges,
+  Inject,
+} from '@angular/core';
 import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
+import { GLOBAL_CONFIG, GlobalConfig } from '../../mat-progress-buttons.injection-token';
 
 @Component({
   // tslint:disable-next-line:component-selector
   selector: 'mat-bar-button',
   templateUrl: './bar-button.component.html',
-  styleUrls: ['./bar-button.component.scss']
+  styleUrls: ['./bar-button.component.scss'],
 })
 export class MatBarButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
-  @Input() active: boolean;
-  @Input() disabled: boolean;
+  @Input() buttonId: string;
+
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+
   @HostListener('click', ['$event'])
-  public onClick(event: MouseEvent) {
+  handleClick(event: MouseEvent): void {
     if (!this.options.disabled && !this.options.active) {
       this.btnClick.emit(event);
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.active) {
-      this.options.active = changes.active.currentValue;
-    }
-    if (changes.disabled) {
-      this.options.disabled = changes.disabled.currentValue;
-    }
+  constructor(@Inject(GLOBAL_CONFIG) private config: GlobalConfig) {}
+
+  get configExists(): boolean {
+    return !!this.buttonId && !!this.config;
+  }
+
+  get globalConfig(): MatProgressButtonOptions {
+    return this.configExists
+      ? this.config.find((item) => item.id === this.buttonId)
+      : this.options;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.options = { ...this.globalConfig, ...this.options };
   }
 }

--- a/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.ts
+++ b/projects/mat-progress-buttons/src/lib/component/bar-button/bar-button.component.ts
@@ -20,6 +20,8 @@ import { GLOBAL_CONFIG, GlobalConfig } from '../../mat-progress-buttons.injectio
 export class MatBarButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
   @Input() buttonId: string;
+  @Input() active: boolean;
+  @Input() disabled: boolean;
 
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
@@ -44,5 +46,11 @@ export class MatBarButtonComponent implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     this.options = { ...this.globalConfig, ...this.options };
+    if (changes.active) {
+      this.options.active = changes.active.currentValue;
+    }
+    if (changes.disabled) {
+      this.options.disabled = changes.disabled.currentValue;
+    }
   }
 }

--- a/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.spec.ts
+++ b/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.spec.ts
@@ -1,16 +1,23 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatSpinnerButtonComponent } from './spinner-button.component';
-import {MatProgressButtonsModule } from '../../mat-progress-buttons.module';
+import { MatProgressButtonsModule } from '../../mat-progress-buttons.module';
 
 describe('MatBarButtonComponent', () => {
   let component: MatSpinnerButtonComponent;
   let fixture: ComponentFixture<MatSpinnerButtonComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [MatProgressButtonsModule]
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          MatProgressButtonsModule.forRoot([{ active: true, text: 'test' }]),
+        ],
+        providers: [
+          { provide: 'Global Config', useValue: { active: true, text: 'test' } },
+        ],
+      }).compileComponents();
+    })
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MatSpinnerButtonComponent);
@@ -20,7 +27,7 @@ describe('MatBarButtonComponent', () => {
       active: false,
       buttonColor: 'primary',
       text: 'test button',
-      disabled: false
+      disabled: false,
     };
     fixture.detectChanges();
   });
@@ -34,7 +41,7 @@ describe('MatBarButtonComponent', () => {
     component.btnClick.subscribe(spy);
 
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith(event);
@@ -46,7 +53,7 @@ describe('MatBarButtonComponent', () => {
 
     component.options = { active: true, text: 'test button' };
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).not.toHaveBeenCalled();
   });
@@ -57,7 +64,7 @@ describe('MatBarButtonComponent', () => {
 
     component.options = { active: false, disabled: true, text: 'test button' };
     const event = new MouseEvent('click', { bubbles: true });
-    component.onClick(event);
+    component.handleClick(event);
 
     expect(spy).not.toHaveBeenCalled();
   });

--- a/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
+++ b/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
@@ -1,31 +1,48 @@
-import { Component, Input, Output, HostListener, EventEmitter, OnChanges, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  HostListener,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+  Inject,
+} from '@angular/core';
 import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
+import { GLOBAL_CONFIG, GlobalConfig } from '../../mat-progress-buttons.injection-token';
 
 @Component({
   // tslint:disable-next-line:component-selector
   selector: 'mat-spinner-button',
   templateUrl: './spinner-button.component.html',
-  styleUrls: ['./spinner-button.component.scss']
+  styleUrls: ['./spinner-button.component.scss'],
 })
 export class MatSpinnerButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
-  @Input() active: boolean;
-  @Input() disabled: boolean;
+  @Input() buttonId: string;
 
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
+
   @HostListener('click', ['$event'])
-  public onClick(event: MouseEvent) {
+  public handleClick(event: MouseEvent): void {
     if (!this.options.disabled && !this.options.active) {
       this.btnClick.emit(event);
     }
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes.active) {
-      this.options.active = changes.active.currentValue;
-    }
-    if (changes.disabled) {
-      this.options.disabled = changes.disabled.currentValue;
-    }
+  constructor(@Inject(GLOBAL_CONFIG) private config: GlobalConfig) {}
+
+  get configExists(): boolean {
+    return !!this.buttonId && !!this.config;
+  }
+
+  get globalConfig(): MatProgressButtonOptions {
+    return this.configExists
+      ? this.config.find((item) => item.id === this.buttonId)
+      : this.options;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    this.options = { ...this.globalConfig, ...this.options };
   }
 }

--- a/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
+++ b/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
@@ -9,7 +9,10 @@ import {
   Inject,
 } from '@angular/core';
 import { MatProgressButtonOptions } from '../../mat-progress-buttons.interface';
-import { GLOBAL_CONFIG, GlobalConfig } from '../../mat-progress-buttons.injection-token';
+import {
+  GLOBAL_CONFIG,
+  GlobalConfig,
+} from '../../mat-progress-buttons.injection-token';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -20,6 +23,8 @@ import { GLOBAL_CONFIG, GlobalConfig } from '../../mat-progress-buttons.injectio
 export class MatSpinnerButtonComponent implements OnChanges {
   @Input() options: MatProgressButtonOptions;
   @Input() buttonId: string;
+  @Input() active: boolean;
+  @Input() disabled: boolean;
 
   @Output() btnClick: EventEmitter<MouseEvent> = new EventEmitter<MouseEvent>();
 
@@ -43,6 +48,12 @@ export class MatSpinnerButtonComponent implements OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
+    if (changes.active) {
+      this.options.active = changes.active.currentValue;
+    }
+    if (changes.disabled) {
+      this.options.disabled = changes.disabled.currentValue;
+    }
     this.options = { ...this.globalConfig, ...this.options };
   }
 }

--- a/projects/mat-progress-buttons/src/lib/mat-progress-buttons.injection-token.ts
+++ b/projects/mat-progress-buttons/src/lib/mat-progress-buttons.injection-token.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from '@angular/core';
+import { MatProgressButtonOptions } from './mat-progress-buttons.interface';
+
+export interface Config extends MatProgressButtonOptions {
+  id?: string;
+}
+
+export type GlobalConfig = Config[];
+
+export const GLOBAL_CONFIG = new InjectionToken<GlobalConfig>('Global Config');

--- a/projects/mat-progress-buttons/src/lib/mat-progress-buttons.interface.ts
+++ b/projects/mat-progress-buttons/src/lib/mat-progress-buttons.interface.ts
@@ -2,7 +2,7 @@ import { ThemePalette } from '@angular/material/core';
 import { ProgressSpinnerMode } from '@angular/material/progress-spinner';
 
 export interface MatProgressButtonOptions {
-  active: boolean;
+  active?: boolean;
   text: string;
   spinnerText?: string;
   buttonColor?: ThemePalette;
@@ -21,6 +21,7 @@ export interface MatProgressButtonOptions {
   type?: string;
   customClass?: string;
   buttonIcon?: MatProgressButtonIcon;
+  id?: string;
 }
 
 interface MatProgressButtonIcon {

--- a/projects/mat-progress-buttons/src/lib/mat-progress-buttons.module.ts
+++ b/projects/mat-progress-buttons/src/lib/mat-progress-buttons.module.ts
@@ -8,6 +8,7 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatRippleModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
+import { GLOBAL_CONFIG, GlobalConfig } from './mat-progress-buttons.injection-token';
 
 // Export module's public API
 export { MatSpinnerButtonComponent } from './component/spinner-button/spinner-button.component';
@@ -21,21 +22,18 @@ export { MatProgressButtonOptions } from './mat-progress-buttons.interface';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatRippleModule,
-    MatIconModule
+    MatIconModule,
   ],
-  exports: [
-    MatSpinnerButtonComponent,
-    MatBarButtonComponent
-  ],
-  declarations: [
-    MatSpinnerButtonComponent,
-    MatBarButtonComponent
-  ]
+  exports: [MatSpinnerButtonComponent, MatBarButtonComponent],
+  declarations: [MatSpinnerButtonComponent, MatBarButtonComponent],
 })
 export class MatProgressButtonsModule {
-  static forRoot(): ModuleWithProviders<MatProgressButtonsModule> {
+  static forRoot(
+    config?: GlobalConfig
+  ): ModuleWithProviders<MatProgressButtonsModule> {
     return {
-      ngModule: MatProgressButtonsModule
+      ngModule: MatProgressButtonsModule,
+      providers: [{ provide: GLOBAL_CONFIG, useValue: config }],
     };
   }
 }


### PR DESCRIPTION
Fixes #30 


### Global Options

Optionally pass default `MatProgressButtonOptions` in `forRoot` in side your app.modlue.ts for each button as an array. 

```typescript
const button1: MatProgressButtonOptions = {
  id: 'button1', // Id should match the [buttonId] input
  ...
};

@NgModule({
  imports: [
    MatProgressButtonsModule.forRoot([button1]),
  ],
  declarations: [HomeComponent],
})
```

#### NB: add the id above should match the id provided in the `[buttonId]` input.

```html
<mat-bar-button
  (btnClick)="handleClick()"
  [buttonId]="'button1'"
  [active]="buttonActiveState"
></mat-bar-button>
```
`[options]` will override Global Options provided in `forRoot`
