### PR TITLE
dev: let the node workflow pass, even if not releasing

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
I couldn't see a way to have the create-release workflow not try to
create if a tag already existed, so the easiest thing to do is to ignore
any failures that might happen.