### PR TITLE
Fix ngOnChanges not being triggered by changing buttonOptions

### DIFF
--- a/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
+++ b/projects/mat-progress-buttons/src/lib/component/spinner-button/spinner-button.component.ts
@@ -47,6 +47,14 @@ export class MatSpinnerButtonComponent implements OnChanges {
       : this.options;
   }
 
+  private mergeObjects(globalOptions: MatProgressButtonOptions, options: MatProgressButtonOptions): void {
+    for (const key in globalOptions) {
+      if (options[key] === undefined) {
+        options[key] = globalOptions[key];
+      }
+    }
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     if (changes.active) {
       this.options.active = changes.active.currentValue;
@@ -54,6 +62,6 @@ export class MatSpinnerButtonComponent implements OnChanges {
     if (changes.disabled) {
       this.options.disabled = changes.disabled.currentValue;
     }
-    this.options = { ...this.globalConfig, ...this.options };
+    this.mergeObjects(this.globalConfig, this.options);
   }
 }


### PR DESCRIPTION
ngOnChanges is not triggered when accessed like this:
`buttonOptions.active = true`
(issue: https://github.com/michaeldoye/mat-progress-buttons/issues/91)

This is caused by this line:
`this.options = { ...this.globalConfig, ...this.options };`

A new "options" Object is created and the one given as input initially isn't observed anymore.
This PR should fix this since no new object is created but the two objects are being merged